### PR TITLE
경로 지하철역 이름 표시 수정

### DIFF
--- a/appFrontend/src/global/apis/hooks.ts
+++ b/appFrontend/src/global/apis/hooks.ts
@@ -18,6 +18,7 @@ import { RawSubwayLineName, MyRoutesType, SubwayStrEnd } from './entity';
 import { AxiosError } from 'axios';
 import { subwayFreshLineName } from '@/global/utils';
 import { useAppSelect } from '@/store';
+import { useMemo } from 'react';
 
 /**
  * 지하철역 검색 훅
@@ -37,8 +38,20 @@ export const useSearchStationName = (nameValue: string) => {
 
   const freshData = data ? subwayFreshLineName(data) : [];
 
+  const deduplicatedStationData = useMemo(() => {
+    if (!freshData) return [];
+    const uniqueStations = new Set();
+    return freshData.filter((item) => {
+      const key = `${item.stationName.split('(')[0]}-${item.stationLine}`;
+      const isDuplicate = uniqueStations.has(key);
+      uniqueStations.add(key);
+      return !isDuplicate;
+    });
+  }, [freshData]);
   return {
-    searchResultData: freshData.sort((a, b) => a.stationName.localeCompare(b.stationName)),
+    searchResultData: deduplicatedStationData.sort((a, b) =>
+      a.stationName.localeCompare(b.stationName),
+    ),
   };
 };
 
@@ -51,7 +64,20 @@ export const useGetSearchHistory = () => {
     enabled: isVerifiedUser === 'success auth',
   });
   const freshData = data?.map((item) => ({ name: item.stationName, line: item.stationLine }));
-  return { historyData: freshData ? subwayFreshLineName(freshData) : [] };
+
+  const deduplicatedStationData = useMemo(() => {
+    if (!freshData) return [];
+    const uniqueStations = new Set();
+    return freshData.filter((item) => {
+      const key = `${item.name.split('(')[0]}-${item.line}`;
+      const isDuplicate = uniqueStations.has(key);
+      uniqueStations.add(key);
+      return !isDuplicate;
+    });
+  }, [freshData]);
+  return {
+    historyData: deduplicatedStationData ? subwayFreshLineName(deduplicatedStationData) : [],
+  };
 };
 
 /**

--- a/appFrontend/src/global/components/subwaySimplePath/PathLineNumName.tsx
+++ b/appFrontend/src/global/components/subwaySimplePath/PathLineNumName.tsx
@@ -18,7 +18,7 @@ const PathLineNumName = ({ lane, stationName }: PathLineNumNameProps) => {
         marginBottom: Dimensions.get('window').fontScale * 22,
       }}
     >
-      <View style={{ width: 42 }} />
+      <View className="w-42" />
       <View
         style={{
           width: Dimensions.get('window').fontScale * 18,
@@ -42,17 +42,18 @@ const PathLineNumName = ({ lane, stationName }: PathLineNumNameProps) => {
       </View>
 
       <View
-        className="absolute flex-row"
+        className="absolute flex flex-row justify-center w-46"
         style={{
           top: Dimensions.get('window').fontScale * 22,
         }}
       >
         <FontText
-          value={subwayNameCutting(stationName)}
+          value={subwayNameCutting(stationName.split('(')[0])}
           textSize="12px"
           textWeight="Medium"
           textColor={subwayLineColor(lane.stationCode)}
           textAlign="center"
+          className="text-center"
         />
         {lane.direct && (
           <FontText

--- a/appFrontend/src/global/components/subwaySimplePath/PathLineNumName.tsx
+++ b/appFrontend/src/global/components/subwaySimplePath/PathLineNumName.tsx
@@ -42,7 +42,7 @@ const PathLineNumName = ({ lane, stationName }: PathLineNumNameProps) => {
       </View>
 
       <View
-        className="absolute flex flex-row justify-center w-46"
+        className="absolute flex flex-col justify-center w-54"
         style={{
           top: Dimensions.get('window').fontScale * 22,
         }}
@@ -53,12 +53,11 @@ const PathLineNumName = ({ lane, stationName }: PathLineNumNameProps) => {
           textWeight="Medium"
           textColor={subwayLineColor(lane.stationCode)}
           textAlign="center"
-          className="text-center"
         />
         {lane.direct && (
           <FontText
-            className="ml-2"
             value="급행"
+            textAlign="center"
             textSize="12px"
             textWeight="Regular"
             textColor="#EB5147"

--- a/appFrontend/src/global/utils/subwayLine.ts
+++ b/appFrontend/src/global/utils/subwayLine.ts
@@ -423,8 +423,6 @@ export const subwayNameCutting = (name: string) => {
       return '월드컵\n경기장';
     case '부천종합운동장':
       return '부천\n종합운동장';
-    case '석남(거북시장)':
-      return '석남\n(거북시장)';
     case '어린이대공원':
       return '어린이\n대공원';
     case '신대방삼거리':
@@ -445,14 +443,6 @@ export const subwayNameCutting = (name: string) => {
       return '압구정\n로데오';
     case '남동인더스파크':
       return '남동\n인더스파크';
-    case '녹사평(용산구청)':
-      return '녹사평\n(용산구청)';
-    case '봉화산(서울의료원)':
-      return '봉화산';
-    case '시민공원(문화창작지대)':
-      return '시민공원';
-    case '신창(순천향대)':
-      return '신창\n(순천향대)';
     case '양재시민의숲':
       return '양재\n시민의숲';
     case '용인중앙시장':
@@ -463,10 +453,8 @@ export const subwayNameCutting = (name: string) => {
       return '운동장.\n송담대';
     case '전대.에버랜드':
       return '전대.\n에버랜드';
-    case '주안국가산단(인천J밸리)':
+    case '주안국가산단':
       return '주안\n국가산단';
-    case '총신대입구(이수)':
-      return '총신대입구\n(이수)';
     case '북한산보국문':
       return '북한산\n보국문';
     case '경기도청북부청사':
@@ -475,14 +463,6 @@ export const subwayNameCutting = (name: string) => {
       return '경전철\n의정부';
     case '가정중앙시장':
       return '가정\n중앙시장';
-    case '가정(루원시티)':
-      return '가정\n루원시티';
-    case '검단오류(검단산업단지)':
-      return '검단오류';
-    case '관악산(서울대)':
-      return '관악산\n(서울대)';
-    case '광교(경기대)':
-      return '광교\n(경기대)';
     case '서부여성회관':
       return '서부\n여성회관';
     case '아시아드경기장':
@@ -499,16 +479,8 @@ export const subwayNameCutting = (name: string) => {
       return '서울지방\n병무청';
     case '송도달빛축제공원':
       return '송도달빛\n축제공원';
-    case '광교중앙(아주대)':
-      return '광교중앙\n(아주대)';
-    case '아시아드경기장(공촌사거리)':
+    case '아시아드경기장':
       return '아시아드\n경기장';
-    case '쌍용(나사렛대)':
-      return '쌍용\n(나사렛대)';
-    case '녹사평(용산구청)':
-      return '녹사평\n(용산구청)';
-    case '수유(강북구청)':
-      return '수유\n(강북구청)';
     default:
       return name;
   }

--- a/appFrontend/src/screens/searchPathResultDetailScreen/components/SearchPathDetailItem.tsx
+++ b/appFrontend/src/screens/searchPathResultDetailScreen/components/SearchPathDetailItem.tsx
@@ -198,13 +198,14 @@ const SearchPathDetailItem = ({ data, isLastLane, lineLength }: SearchPathDetail
             backgroundColor: subwayLineColor(data.lanes[0].stationCode),
           }}
         />
-        <FontText
-          value={data.stations[lastIdx].stationName}
-          textSize="18px"
-          textWeight="SemiBold"
-          textColor={subwayLineColor(data.lanes[0].stationCode)}
-          className="absolute top-[-1px] left-36"
-        />
+        <View className="ml-16">
+          <FontText
+            value={data.stations[lastIdx].stationName}
+            textSize="18px"
+            textWeight="SemiBold"
+            textColor={subwayLineColor(data.lanes[0].stationCode)}
+          />
+        </View>
       </View>
       {!isLastLane && (
         <View className="mt-[-20px] ml-[-25px] flex-row items-center">

--- a/appFrontend/src/screens/searchStationScreen/index.tsx
+++ b/appFrontend/src/screens/searchStationScreen/index.tsx
@@ -135,7 +135,7 @@ const SearchStationScreen = () => {
                 <IconClock />
                 <StationInfoBox>
                   <FontText
-                    value={stationName}
+                    value={stationName.split('(')[0]}
                     textSize="16px"
                     textWeight="Medium"
                     lineHeight={21}
@@ -163,7 +163,7 @@ const SearchStationScreen = () => {
                 <IconLocationPin />
                 <StationInfoBox>
                   <FontText
-                    value={stationName}
+                    value={stationName.split('(')[0]}
                     textSize="16px"
                     textWeight="Medium"
                     lineHeight={21}


### PR DESCRIPTION
### 변경사항
- 경로 지하철역 5글자 수 기준으로 표시
   - 괄호 제거 (ex.`하남시청(이름.이름)` -> `하남시청`)
- 지하철역 검색 히스토리 및 검색 결과 괄호 제거

### 참고사항
- `FontText` 수정해보려했는데 ui 컴포넌트들이 서로 연관되있어서 수정하려면 관련 컴포넌트도 같이 수정해야할거 같아요. pr 나눠서 작업하려합니다.