### PR TITLE
Fix: 온보딩 경로 저장 플로우 개선 및 저장 경로 안정성 강화

### DIFF
--- a/appFrontend/CLAUDE.md
+++ b/appFrontend/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**가는길지금 (GaziNow)** is a React Native (v0.73.4) app for real-time Seoul subway route search and issue tracking. Users can save commute routes, receive push notifications for subway issues, and browse live issue reports by line.
+
+## Commands
+
+```bash
+# Install dependencies (includes iOS pod install)
+yarn i
+
+# Run dev server
+yarn start
+
+# Run on device/simulator
+yarn android:development      # Android dev env
+yarn android:production       # Android prod env
+yarn ios:development          # iOS dev env
+yarn ios:production           # iOS prod env
+
+# Lint
+yarn lint
+
+# Test
+yarn test
+
+# Full clean (nukes node_modules, Pods, Android build artifacts)
+yarn clean
+
+# Build Android release
+yarn aab:android              # AAB bundle
+yarn apk:android              # APK
+```
+
+Environment files: `.env.development` and `.env.production`. Variables are accessed via `@env` (react-native-dotenv). Key env vars: `API_BASE_URL`, `MODE`, `SENTRY_DSN`, `AMPLITUDE_API_KEY`.
+
+## Path Aliases
+
+Defined in `babel.config.js` via `babel-plugin-module-resolver`:
+
+| Alias | Resolves to |
+|---|---|
+| `@` | `./src` |
+| `@assets` | `./src/assets` |
+| `@global` | `./src/global` |
+| `@screens` | `./src/screens` |
+| `@store` | `./src/store` |
+
+## Architecture
+
+### Navigation
+
+`RootNavigation` (stack) is the top-level navigator. It contains:
+- `AuthStack` → `AuthNavigation` (Landing / SignIn / SignUp)
+- `MainBottomTab` → `MainBottomTabNavigation` (Home / NOW / My)
+- `IssueStack` → `IssueNavigation`
+- `MyPageNavigation` (account settings, notifications)
+- `OnboardingNavigation` (first-time route setup flow)
+- `SavePathNavigation` (saved route management)
+- `SubwayPathDetail` (full-screen path detail)
+
+All navigation param types are centralized in `src/navigation/types/navigation.ts`. Each stack has its own `*ParamList` type exported from there.
+
+Use `useRootNavigation<RouteName>()` (from `src/navigation/RootNavigation.tsx`) for type-safe root-level navigation.
+
+### API Layer
+
+Two Axios instances in `src/global/apis/index.ts`:
+- `publicServiceAPI` — unauthenticated requests
+- `authServiceAPI` — attaches Bearer token from `EncryptedStorage`, auto-refreshes on 401, redirects to `AuthStack` on refresh failure
+
+API functions (`func.ts`) → React Query hooks (`hooks.ts`) → screens. Screen-specific API code lives in `src/screens/<screen>/apis/`.
+
+Types for all API entities (subway lines, paths, issues, pagination) are in `src/global/apis/entity.ts`. Key type distinction: `OriginLineName` (raw API format, e.g. `'수도권 2호선'`) vs `DisplayLineName` (app display format, e.g. `'2호선'`). Conversion utilities live in `src/global/utils/subwayLine.ts`.
+
+### State Management
+
+Redux Toolkit store (`src/store/`) with two slices:
+- `auth` — user nickname, email, `isVerifiedUser` state (`'yet' | 'success auth' | 'fail auth'`)
+- `subwaySearch` — departure/arrival station selection
+
+Use `useAppSelect` (typed selector from `src/store/`) to read state.
+
+### Styling
+
+NativeWind (Tailwind CSS for React Native, v2). Custom theme values are in `tailwind.config.js` including:
+- Pixel-exact spacing (0–999px as `spacing`, `borderRadius`, etc.)
+- Subway line colors: `subway-line-1` through named lines (`subway-line-kj`, etc.)
+- App colors: `light-blue` (#346BF7), `light-green`, `light-red`
+
+The `COLOR` constant object in `src/global/constants/color.ts` mirrors these for use in JS style props.
+
+### Global Shared Code
+
+- `src/global/ui/` — reusable UI primitives: `FontText`, `Input`, `TimePicker`, `Toast`, `Toggle`
+- `src/global/components/` — shared feature components (loading states, network error screen)
+- `src/global/constants/` — `COLOR`, `LINE_CAPSULES`, analytics event names, subway line data
+- `src/global/utils/` — `getEncryptedStorage`/`setEncryptedStorage` (token storage), subway line name converters
+
+### Analytics
+
+Amplitude (primary) and Firebase Analytics (screen views) are both active. `src/analytics/` contains event tracking functions organized by tab/feature (`auth.events.ts`, `map.events.ts`, `now.events.ts`, `my.events.ts`, `register.events.ts`). Call these from UI interaction handlers, not inside hooks.
+
+### Fonts
+
+Pretendard (Bold, Medium, Regular, SemiBold) in `src/assets/fonts/`. Use `FontText` component with the `fontWeight` prop rather than setting font families directly.
+
+### Push Notifications
+
+`@notifee/react-native` handles local notifications. `@react-native-firebase/messaging` handles FCM. Notification logic is bootstrapped in `MainBottomTabNavigation` (channel creation on first run) and `RootNavigation` (`pushNotification()` call).
+
+### Error Monitoring
+
+Sentry is initialized in `src/App.tsx`, enabled only in production (`MODE === 'production'`). API errors in `func.ts` use `Sentry.captureException` with structured context objects.

--- a/appFrontend/clean_all.sh
+++ b/appFrontend/clean_all.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =========================
+# Project-specific defaults
+# =========================
+IOS_SCHEME="gazinow"
+IOS_WORKSPACE="ios/gazinow.xcworkspace"
+
+# =========================
+# Detect IDs
+# =========================
+detect_android_app_id() {
+  local gradle_file="android/app/build.gradle"
+  if [[ -f "$gradle_file" ]]; then
+    # applicationId "com.xxx"
+    local id
+    id=$(grep -E 'applicationId\s+"[^"]+"' "$gradle_file" | head -n 1 | sed -E 's/.*applicationId\s+"([^"]+)".*/\1/')
+    if [[ -n "${id:-}" ]]; then
+      echo "$id"
+      return
+    fi
+  fi
+  echo ""
+}
+
+detect_ios_bundle_id() {
+  local pbxproj="ios/gazinow.xcodeproj/project.pbxproj"
+  if [[ -f "$pbxproj" ]]; then
+    # PRODUCT_BUNDLE_IDENTIFIER = com.xxx;
+    # $(...) 같은 변수 아닌 실제 값 우선
+    local id
+    id=$(grep -E 'PRODUCT_BUNDLE_IDENTIFIER\s*=\s*[^;]+' "$pbxproj" \
+      | grep -v '\$' \
+      | head -n 1 \
+      | sed -E 's/.*=\s*([^;]+);/\1/' \
+      | tr -d ' ')
+    if [[ -n "${id:-}" ]]; then
+      echo "$id"
+      return
+    fi
+  fi
+  echo ""
+}
+
+ANDROID_APP_ID="$(detect_android_app_id)"
+IOS_BUNDLE_ID="$(detect_ios_bundle_id)"
+
+echo "📌 Detected ANDROID_APP_ID: ${ANDROID_APP_ID:-"(not found)"}"
+echo "📌 Detected IOS_BUNDLE_ID:    ${IOS_BUNDLE_ID:-"(not found)"}"
+
+# =========================
+# Kill / Clean caches
+# =========================
+echo "🧯 Kill Metro/Node..."
+pkill -f "react-native start" || true
+pkill -f "metro" || true
+pkill -f "node.*metro" || true
+
+if command -v watchman >/dev/null 2>&1; then
+  echo "🧹 watchman watch-del-all..."
+  watchman watch-del-all || true
+fi
+
+echo "🧹 Remove JS caches..."
+rm -rf "$TMPDIR/metro-"* "$TMPDIR/haste-map-"* "$TMPDIR/react-"* 2>/dev/null || true
+rm -rf ~/.metro 2>/dev/null || true
+
+echo "🧹 Remove node_modules..."
+rm -rf node_modules
+
+echo "📦 Install JS deps..."
+if [[ -f yarn.lock ]]; then
+  yarn install
+else
+  npm ci || npm install
+fi
+
+# =========================
+# Android: clean + uninstall
+# =========================
+echo "🤖 Android clean..."
+rm -rf android/.gradle android/build android/app/build
+( cd android && ./gradlew clean )
+
+if command -v adb >/dev/null 2>&1; then
+  if [[ -n "${ANDROID_APP_ID:-}" ]]; then
+    echo "📵 Android uninstall: $ANDROID_APP_ID"
+    adb uninstall "$ANDROID_APP_ID" || true
+  else
+    echo "⚠️ ANDROID_APP_ID 못 찾아서 uninstall 스킵 (android/app/build.gradle 확인)"
+  fi
+else
+  echo "⚠️ adb 없음. Android uninstall 스킵"
+fi
+
+# =========================
+# iOS: pods/derivedData clean + uninstall(sim)
+# =========================
+echo "🍏 iOS clean..."
+rm -rf ios/Pods ios/Podfile.lock ios/build
+rm -rf ~/Library/Developer/Xcode/DerivedData/* 2>/dev/null || true
+
+if command -v pod >/dev/null 2>&1; then
+  ( cd ios && pod install )
+else
+  echo "⚠️ CocoaPods 없음. (pod install 수동 필요)"
+fi
+
+if command -v xcrun >/dev/null 2>&1; then
+  # booted simulator에서 앱 삭제
+  if [[ -n "${IOS_BUNDLE_ID:-}" ]]; then
+    echo "📵 iOS uninstall (sim booted): $IOS_BUNDLE_ID"
+    xcrun simctl uninstall booted "$IOS_BUNDLE_ID" || true
+  else
+    echo "⚠️ IOS_BUNDLE_ID 못 찾아서 sim uninstall 스킵 (ios/gazinow.xcodeproj/project.pbxproj 확인)"
+  fi
+fi
+
+echo ""
+echo "✅ FULL CLEAN DONE."
+echo "-------------------"
+echo "Now reinstall/run:"
+echo "  - Android: npx react-native run-android"
+echo "  - iOS:     npx react-native run-ios --scheme \"$IOS_SCHEME\""

--- a/appFrontend/src/global/apis/entity.ts
+++ b/appFrontend/src/global/apis/entity.ts
@@ -171,6 +171,7 @@ export interface SubPath {
   stations: {
     index: number;
     stationName: string;
+    stationCode?: number;
     issueSummary: IssueSummary[];
   }[];
 }
@@ -188,9 +189,22 @@ export interface SaveMyRoutesType extends Path {
   walkingTimeToEndStation?: number;
 }
 
-export interface MyRoutesType extends Path {
+/**
+ * get_roads(저장된 경로 조회) 응답 데이터
+ *
+ * 검색 경로(Path)와 달리 firstStartStation/stationTransitCount/myPath/myPathId가
+ * 응답에 없고, transitStationList는 null로 내려온다.
+ */
+export interface MyRoutesType {
   id: number;
+  totalTime: number;
   roadName: string;
+  lastEndStation: string;
+  notification?: boolean;
+  transitStationList: { stationsName: string; line: OriginLineName }[] | null;
+  subPaths: SubPath[];
+  walkingTimeFromStartStation?: number;
+  walkingTimeToEndStation?: number;
 }
 
 export interface SubwayStrEnd {

--- a/appFrontend/src/global/components/subwaySimplePath/index.tsx
+++ b/appFrontend/src/global/components/subwaySimplePath/index.tsx
@@ -19,7 +19,7 @@ const SubwaySimplePath = ({
   isHideIsuue = false,
 }: Props) => {
   const freshLanesPathData = useMemo(() => {
-    return pathData.filter((item) => !!item.stations.length);
+    return pathData.filter((item) => !!item.stations?.length);
   }, [pathData]);
   const maxLength = freshLanesPathData.length;
 

--- a/appFrontend/src/navigation/types/navigation.ts
+++ b/appFrontend/src/navigation/types/navigation.ts
@@ -70,12 +70,30 @@ export type MyPageStackParamList = {
   PersonalTermsScreen: undefined;
 };
 
+/** 온보딩 도보 시간 입력값 */
+export interface OnboardingWalkTime {
+  before: number;
+  after: number;
+}
+
+/** 온보딩 알림 설정 입력값 (경로 저장 후 실제 알림 API 요청에 사용) */
+export interface OnboardingAlertSettings {
+  isPushNotificationOn: boolean;
+  selectedDays: string[];
+  startTime: string;
+  endTime: string;
+}
+
 export type OnboardingStackParamList = {
   Onboarding: undefined;
   OnboardingSwap: undefined;
   OnboardingWalkTime: { newPath: Path };
-  OnboardingSetAlert: { newPath: Path };
-  OnboardingPathName: { newPath: Path };
+  OnboardingSetAlert: { newPath: Path; walkTime: OnboardingWalkTime };
+  OnboardingPathName: {
+    newPath: Path;
+    walkTime: OnboardingWalkTime;
+    alertSettings: OnboardingAlertSettings;
+  };
   OnboardingCompleted: { pathName: unknown };
 };
 

--- a/appFrontend/src/navigation/types/navigation.ts
+++ b/appFrontend/src/navigation/types/navigation.ts
@@ -31,7 +31,7 @@ export type RootStackParamList = {
   };
   OnboardingNavigation: undefined;
   SavePathNavigation: { screen: 'SavedPaths' | 'SwapStation' };
-  SubwayPathDetail: { state?: Path | SubPath[]; notificationId?: number | null };
+  SubwayPathDetail: { state?: Path | MyRoutesType | SubPath[]; notificationId?: number | null };
 };
 
 export type AuthStackStackParamList = {
@@ -44,7 +44,7 @@ export type HomeStackParamList = {
   Home: undefined;
   NotiHistory: undefined;
   SubwayPathResult: undefined;
-  SubwayPathDetail: { state?: Path | SubPath[]; notificationId?: number | null };
+  SubwayPathDetail: { state?: Path | MyRoutesType | SubPath[]; notificationId?: number | null };
   SavedPaths: undefined;
 };
 

--- a/appFrontend/src/screens/homeScreen/components/IssuesBanner.tsx
+++ b/appFrontend/src/screens/homeScreen/components/IssuesBanner.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const IssuesBanner = ({ subPaths, isHomeScreen }: Props) => {
-  const issues = subPaths.filter((subPath) => !!subPath.issueSummary.length);
+  const issues = subPaths.filter((subPath) => !!subPath.issueSummary?.length);
   if (issues.length < 1) return null;
 
   const dispatch = useAppDispatch();
@@ -35,9 +35,9 @@ const IssuesBanner = ({ subPaths, isHomeScreen }: Props) => {
           key={`${index}-${issue}`}
           onPress={() => {
             const trackData = {
-              station_departure: subPaths[1].stations[0].stationName,
-              station_arrival: subPaths.at(-2)?.stations.at(-1)?.stationName!,
-              line_departure: subPaths[1].name,
+              station_departure: subPaths[1]?.stations?.[0]?.stationName!,
+              station_arrival: subPaths.at(-2)?.stations?.at(-1)?.stationName!,
+              line_departure: subPaths[1]?.name,
               line_arrival: subPaths.at(-2)?.name!,
             };
             if (isHomeScreen) {

--- a/appFrontend/src/screens/homeScreen/components/MyRoutes.tsx
+++ b/appFrontend/src/screens/homeScreen/components/MyRoutes.tsx
@@ -1,4 +1,5 @@
 import cn from 'classname';
+import * as Sentry from '@sentry/react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { Shadow } from 'react-native-shadow-2';
 import { useQuery, useQueryClient } from 'react-query';
@@ -81,14 +82,36 @@ const MyRoutes = ({ isVerifiedUser, isRefreshing, setIsRefreshing }: Props) => {
         </View>
       );
     }
-    return myRoutes?.map((myRoute, index) => {
-      const hasIssues = myRoute.subPaths.some((subPath) => !!subPath.issueSummary.length);
+    // 스키마가 맞지 않는 경로(subPaths 누락 등)는 렌더링에서 제외해 앱이 꺼지지 않도록 방어
+    const allRoutes = myRoutes ?? [];
+    const validRoutes = allRoutes.filter(
+      (myRoute) => myRoute && Array.isArray(myRoute.subPaths),
+    );
+
+    // 스키마가 깨진 경로가 섞여 있으면 Sentry로 로깅
+    if (validRoutes.length !== allRoutes.length) {
+      const invalidRoutes = allRoutes.filter(
+        (myRoute) => !myRoute || !Array.isArray(myRoute.subPaths),
+      );
+      Sentry.captureException({
+        target: '내가 저장한 경로 스키마 불일치',
+        input: { invalidCount: invalidRoutes.length, totalCount: allRoutes.length },
+        output: { invalidRoutes },
+      });
+    }
+
+    if (validRoutes.length < 1) {
+      return <NoRoutes />;
+    }
+
+    return validRoutes.map((myRoute, index) => {
+      const hasIssues = myRoute.subPaths.some((subPath) => !!subPath?.issueSummary?.length);
       return (
         <RouteItem
           key={myRoute.id}
           route={myRoute}
           hasIssues={hasIssues}
-          isLastItem={index === myRoutes.length - 1}
+          isLastItem={index === validRoutes.length - 1}
         />
       );
     });

--- a/appFrontend/src/screens/homeScreen/components/MyRoutes.tsx
+++ b/appFrontend/src/screens/homeScreen/components/MyRoutes.tsx
@@ -1,5 +1,5 @@
-import cn from 'classname';
 import * as Sentry from '@sentry/react-native';
+import cn from 'classname';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { Shadow } from 'react-native-shadow-2';
 import { useQuery, useQueryClient } from 'react-query';
@@ -84,9 +84,7 @@ const MyRoutes = ({ isVerifiedUser, isRefreshing, setIsRefreshing }: Props) => {
     }
     // 스키마가 맞지 않는 경로(subPaths 누락 등)는 렌더링에서 제외해 앱이 꺼지지 않도록 방어
     const allRoutes = myRoutes ?? [];
-    const validRoutes = allRoutes.filter(
-      (myRoute) => myRoute && Array.isArray(myRoute.subPaths),
-    );
+    const validRoutes = allRoutes.filter((myRoute) => myRoute && Array.isArray(myRoute.subPaths));
 
     // 스키마가 깨진 경로가 섞여 있으면 Sentry로 로깅
     if (validRoutes.length !== allRoutes.length) {

--- a/appFrontend/src/screens/onboardingScreen/OnboardingPathNameScreen.tsx
+++ b/appFrontend/src/screens/onboardingScreen/OnboardingPathNameScreen.tsx
@@ -1,6 +1,7 @@
+import { AxiosError } from 'axios';
 import cn from 'classname';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useQueryClient } from 'react-query';
+import { useMutation } from 'react-query';
 import React, { useEffect, useMemo, useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useRoute } from '@react-navigation/native';
@@ -13,7 +14,18 @@ import { COLOR } from '@/global/constants';
 import { FontText, Input } from '@/global/ui';
 import { useOnboardingNavigation } from '@/navigation/OnboardingNavigation';
 import { OnboardingStackParamList } from '@/navigation/types/navigation';
-import { trackMapBookmark4Name, trackMapBookmark5Finish } from '@/analytics/map.events';
+import {
+  DepArrNameAlert,
+  trackMapBookmark4Name,
+  trackMapBookmark5Finish,
+  trackMapSearchBookmarkSetting,
+} from '@/analytics/map.events';
+import {
+  disablePathNotiFetch,
+  enablePathNotiSettingsFetch,
+  updatePathNotiSettingsFetch,
+} from '@/screens/myRootScreen/apis/func';
+import { rawTimeToReqTimeFormat } from '@/screens/myRootScreen/util/timeFormatChange';
 import { OnboardingHeader } from './components';
 
 export interface SelectedStationTypes {
@@ -23,10 +35,12 @@ export interface SelectedStationTypes {
 
 const OnboardingPathNameScreen = () => {
   const onboardingNavigation = useOnboardingNavigation();
-  const { newPath } = useRoute().params as {
+  const { newPath, walkTime, alertSettings } = useRoute().params as {
     newPath: OnboardingStackParamList['OnboardingPathName']['newPath'];
+    walkTime: OnboardingStackParamList['OnboardingPathName']['walkTime'];
+    alertSettings: OnboardingStackParamList['OnboardingPathName']['alertSettings'];
   };
-  if (!newPath || !newPath.id) return null;
+  if (!newPath) return null;
 
   const [pathName, setPathName] = useState('출근길');
   const recommendedNames = ['출근길', '퇴근길', '학교가는 길', '집 가는 길'];
@@ -48,11 +62,59 @@ const OnboardingPathNameScreen = () => {
     return Object.values(subPaths).filter((item) => !!item.stations.length);
   }, [newPath]);
 
+  // 경로 저장 + 알림 설정 저장 완료 후 마무리
+  const finishOnboarding = () => {
+    trackMapBookmark5Finish({ ...pathData, name: pathName });
+    showToast('saveRoute');
+    onboardingNavigation.push('OnboardingCompleted', { pathName });
+  };
+
+  const createNotiSettingsBody = (newPathId: number) => ({
+    myPathId: newPathId,
+    dayTimeRanges: alertSettings.selectedDays.map((day) => ({
+      day,
+      fromTime: rawTimeToReqTimeFormat(alertSettings.startTime),
+      toTime: rawTimeToReqTimeFormat(alertSettings.endTime),
+    })),
+  });
+
+  // 알림 설정 저장 (경로 저장 성공 후 1회 호출)
+  const { mutate: enablePathNotiSettingsMutate } = useMutation(updatePathNotiSettingsFetch, {
+    onSuccess: (
+      _: unknown,
+      provider: { dayTimeRanges: { fromTime: string; toTime: string }[] },
+    ) => {
+      const trackData: DepArrNameAlert = {
+        ...pathData,
+        name: pathName,
+        alarm: 'on',
+        starttime: provider.dayTimeRanges[0].fromTime.replace(':', ''),
+        finishtime: provider.dayTimeRanges[0].toTime.replace(':', ''),
+        day: alertSettings.selectedDays.join(', '),
+      };
+      trackMapSearchBookmarkSetting(trackData);
+      finishOnboarding();
+    },
+    onError: (error: AxiosError) => {
+      showToast(
+        error.response?.status === 400 ? 'notiSettingsTimeError' : 'saveNotiSettingsFailed',
+      );
+    },
+  });
+
+  const { mutate: disablePathNotiMutate } = useMutation(disablePathNotiFetch, {
+    onSuccess: () => finishOnboarding(),
+    onError: () => showToast('saveNotiSettingsFailed'),
+  });
+
+  // 경로 저장 (온보딩 전체에서 1회만 호출) -> 성공 시 알림 설정 저장으로 이어진다.
   const { mutate } = useSavedSubwayRoute({
-    onSuccess: async () => {
-      trackMapBookmark5Finish({ ...pathData, name: pathName });
-      onboardingNavigation.push('OnboardingCompleted', { pathName });
-      showToast('saveRoute');
+    onSuccess: (newPathId) => {
+      if (alertSettings.isPushNotificationOn) {
+        enablePathNotiSettingsMutate(createNotiSettingsBody(newPathId));
+      } else {
+        disablePathNotiMutate(newPathId);
+      }
     },
     onError: () => {},
   });
@@ -62,18 +124,20 @@ const OnboardingPathNameScreen = () => {
       ...newPath,
       subPaths: freshSubPathData,
       roadName: pathName,
+      walkingTimeFromStartStation: walkTime.before,
+      walkingTimeToEndStation: walkTime.after,
     });
   };
 
   return (
-    <SafeAreaView className="flex-1 px-16 bg-gray-9f9">
+    <SafeAreaView className="flex-1 bg-gray-9f9 px-16">
       <OnboardingHeader />
 
       <View className="flex-1 space-y-28">
-        <View className="pt-16 pb-14">
+        <View className="pb-14 pt-16">
           <View className="relative">
             <View className="h-6 w-full rounded-3 bg-[#78787833]" />
-            <View className="absolute z-10 w-full h-6 rounded-3 bg-black-717" />
+            <View className="absolute z-10 h-6 w-full rounded-3 bg-black-717" />
           </View>
         </View>
 
@@ -91,7 +155,7 @@ const OnboardingPathNameScreen = () => {
 
         <View className="space-y-16">
           {/* 경로 컴포넌트 */}
-          <View className="p-16 bg-white rounded-14">
+          <View className="rounded-14 bg-white p-16">
             <SubwaySimplePath
               pathData={newPath.subPaths}
               arriveStationName={newPath.lastEndStation}
@@ -100,10 +164,10 @@ const OnboardingPathNameScreen = () => {
           </View>
 
           {/* 새 경로 이름 입력 컴포넌트 */}
-          <View className="p-16 bg-white space-y-7 rounded-14">
+          <View className="space-y-7 rounded-14 bg-white p-16">
             <FontText text="새 경로 이름" className="text-14 leading-21" fontWeight="500" />
             <Input
-              className="px-16 py-12 rounded-5 bg-gray-9f9"
+              className="rounded-5 bg-gray-9f9 px-16 py-12"
               value={pathName}
               onChangeText={(text) => setPathName(text)}
               inputMode="text"
@@ -143,7 +207,7 @@ const OnboardingPathNameScreen = () => {
       <TouchableOpacity className="mb-56 rounded-5 bg-black-717 p-11" onPress={handleSave}>
         <FontText
           text="경로 저장하기"
-          className="text-center text-white text-17 leading-26"
+          className="text-center text-17 leading-26 text-white"
           fontWeight="600"
         />
       </TouchableOpacity>

--- a/appFrontend/src/screens/onboardingScreen/OnboardingPathNameScreen.tsx
+++ b/appFrontend/src/screens/onboardingScreen/OnboardingPathNameScreen.tsx
@@ -9,7 +9,6 @@ import { SubPath } from '@/global/apis/entity';
 import { useSavedSubwayRoute } from '@/global/apis/hooks';
 import { showToast } from '@/global/utils/toast';
 import { SubwaySimplePath } from '@/global/components';
-import LoadingCircle from '@/global/components/animations/LoadingCircle';
 import { COLOR } from '@/global/constants';
 import { FontText, Input } from '@/global/ui';
 import { useOnboardingNavigation } from '@/navigation/OnboardingNavigation';
@@ -49,7 +48,7 @@ const OnboardingPathNameScreen = () => {
     return Object.values(subPaths).filter((item) => !!item.stations.length);
   }, [newPath]);
 
-  const { mutate, isLoading } = useSavedSubwayRoute({
+  const { mutate } = useSavedSubwayRoute({
     onSuccess: async () => {
       trackMapBookmark5Finish({ ...pathData, name: pathName });
       onboardingNavigation.push('OnboardingCompleted', { pathName });
@@ -68,12 +67,6 @@ const OnboardingPathNameScreen = () => {
 
   return (
     <SafeAreaView className="flex-1 px-16 bg-gray-9f9">
-      {isLoading && (
-        <View className="absolute items-center justify-center w-full h-full">
-          <LoadingCircle />
-        </View>
-      )}
-
       <OnboardingHeader />
 
       <View className="flex-1 space-y-28">

--- a/appFrontend/src/screens/onboardingScreen/OnboardingSetAlertScreen.tsx
+++ b/appFrontend/src/screens/onboardingScreen/OnboardingSetAlertScreen.tsx
@@ -1,24 +1,13 @@
-import { AxiosError } from 'axios';
 import cn from 'classname';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useMutation } from 'react-query';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Pressable, TouchableOpacity, View } from 'react-native';
 import { useRoute } from '@react-navigation/core';
 import type { StationDataTypes } from '@/store/modules';
-import { showToast } from '@/global/utils/toast';
 import { FontText, Toggle } from '@/global/ui';
 import { useOnboardingNavigation } from '@/navigation/OnboardingNavigation';
 import { OnboardingStackParamList } from '@/navigation/types/navigation';
-import { DepArrNameAlert, trackMapSearchBookmarkSetting } from '@/analytics/map.events';
-import {
-  disablePathNotiFetch,
-  enablePathNotiSettingsFetch,
-  updatePathNotiSettingsFetch,
-} from '@/screens/myRootScreen/apis/func';
-import { useGetPathNotiQuery } from '@/screens/myRootScreen/apis/hooks';
 import SetNotiTimesBtn from '@/screens/myRootScreen/components/SetNotiTimesBtn';
-import { rawTimeToReqTimeFormat } from '@/screens/myRootScreen/util/timeFormatChange';
 import { OnboardingHeader } from './components';
 
 export interface SelectedStationTypes {
@@ -28,30 +17,16 @@ export interface SelectedStationTypes {
 
 const OnboardingSetAlertScreen = () => {
   const onboardingNavigation = useOnboardingNavigation();
-  const { newPath } = useRoute().params as {
-    newPath: OnboardingStackParamList['OnboardingWalkTime']['newPath'];
+  const { newPath, walkTime } = useRoute().params as {
+    newPath: OnboardingStackParamList['OnboardingSetAlert']['newPath'];
+    walkTime: OnboardingStackParamList['OnboardingSetAlert']['walkTime'];
   };
-  if (!newPath || !newPath.id) return null;
+  if (!newPath) return null;
 
-  const { pathNotiData } = useGetPathNotiQuery(newPath.id);
+  // 온보딩은 항상 새 경로이므로 기존 알림 설정은 없다. 기본값으로 시작한다.
   const [isPushNotificationOn, setIsPushNotificationOn] = useState<boolean>(false);
   const [savedStartTime, setSavedStartTime] = useState<string>('07:00');
   const [savedEndTime, setSavedEndTime] = useState<string>('09:00');
-
-  // 저장된 설정 불러오기
-  useEffect(() => {
-    if (pathNotiData?.enabled) {
-      setIsPushNotificationOn(true);
-      setSelectedDays(pathNotiData.notificationTimes.map((notiTimes) => notiTimes.dayOfWeek));
-      setSavedStartTime(pathNotiData?.notificationTimes[0].fromTime);
-      setSavedEndTime(pathNotiData?.notificationTimes[0].toTime);
-    } else {
-      setIsPushNotificationOn(false);
-      setSavedStartTime('07:00');
-      setSavedEndTime('09:00');
-      setSelectedDays([]);
-    }
-  }, [pathNotiData]);
 
   // 푸시 알림 on 토글
   const handlePushNotificationOnToggle = () => {
@@ -72,80 +47,19 @@ const OnboardingSetAlertScreen = () => {
     });
   };
 
-  const routeInfo = {
-    station_departure: newPath.transitStationList[0].stationsName,
-    station_arrival: newPath.transitStationList.at(-1)?.stationsName!,
-    line_departure: newPath.transitStationList[0].line,
-    line_arrival: newPath.transitStationList.at(-1)?.line!,
-    name: '출근길',
-  };
-
-  const buildOnTrackData = (provider: {
-    dayTimeRanges: { day: string; fromTime: string; toTime: string }[];
-  }): DepArrNameAlert => ({
-    ...routeInfo,
-    alarm: 'on' as const,
-    starttime: provider.dayTimeRanges[0].fromTime.replace(':', ''),
-    finishtime: provider.dayTimeRanges[0].toTime.replace(':', ''),
-    day: provider.dayTimeRanges.map(({ day }) => day).join(', '),
-  });
-
-  const handleAfterSuccess = (trackData: DepArrNameAlert) => {
-    showToast('saveNotiSettingsSuccess');
-
-    trackMapSearchBookmarkSetting(trackData);
-
-    onboardingNavigation.push('OnboardingPathName', { newPath });
-  };
-
-  const mutationOptions = {
-    onSuccess: (_: unknown, provider: any) => {
-      handleAfterSuccess(buildOnTrackData(provider));
-    },
-    onError: (error: AxiosError) => {
-      showToast(
-        error.response?.status === 400 ? 'notiSettingsTimeError' : 'saveNotiSettingsFailed',
-      );
-    },
-  };
-
-  // 완료 버튼 클릭 시 요청 전송
-  const { mutate: enablePathNotiSettingsMutate } = useMutation(
-    enablePathNotiSettingsFetch,
-    mutationOptions,
-  );
-  const { mutate: updatePathNotiSettingsMutate } = useMutation(
-    updatePathNotiSettingsFetch,
-    mutationOptions,
-  );
-
-  const { mutate: disablePathNotiMutate } = useMutation(disablePathNotiFetch, {
-    onSuccess: () => handleAfterSuccess({ ...routeInfo, alarm: 'off' as const }),
-    onError: () => showToast('saveNotiSettingsFailed'),
-  });
-
-  const createNotiSettingsBody = (selectedDays: string[], newPathId: number) => {
-    return {
-      myPathId: newPathId,
-      dayTimeRanges: selectedDays.map((day) => ({
-        day,
-        fromTime: rawTimeToReqTimeFormat(savedStartTime),
-        toTime: rawTimeToReqTimeFormat(savedEndTime),
-      })),
-    };
-  };
-
+  // 경로/알림 저장은 마지막 단계(OnboardingPathName)에서 1회씩만 수행한다.
+  // 여기서는 알림 설정 입력값만 다음 화면으로 넘긴다.
   const saveSettingsHandler = () => {
-    if (!newPath.id) return;
-
-    const notiSettings = createNotiSettingsBody(selectedDays, newPath.id);
-    if (!isPushNotificationOn) {
-      disablePathNotiMutate(newPath.id);
-    } else if (pathNotiData?.enabled) {
-      updatePathNotiSettingsMutate(notiSettings);
-    } else {
-      enablePathNotiSettingsMutate(notiSettings);
-    }
+    onboardingNavigation.push('OnboardingPathName', {
+      newPath,
+      walkTime,
+      alertSettings: {
+        isPushNotificationOn,
+        selectedDays,
+        startTime: savedStartTime,
+        endTime: savedEndTime,
+      },
+    });
   };
 
   return (

--- a/appFrontend/src/screens/onboardingScreen/OnboardingSwapScreen.tsx
+++ b/appFrontend/src/screens/onboardingScreen/OnboardingSwapScreen.tsx
@@ -8,7 +8,6 @@ import type { StationDataTypes } from '@/store/modules';
 import { Path } from '@/global/apis/entity';
 import { useGetSearchPaths } from '@/global/apis/hooks';
 import { SubwaySimplePath } from '@/global/components';
-import LoadingCircle from '@/global/components/animations/LoadingCircle';
 import { ARRIVAL_STATION, COLOR, DEPARTURE_STATION } from '@/global/constants';
 import { FontText } from '@/global/ui';
 import { useOnboardingNavigation } from '@/navigation/OnboardingNavigation';
@@ -144,11 +143,6 @@ const OnboardingSwapScreen = () => {
           </View>
 
           <View className="px-16 pt-16">
-            {isLoading && (
-              <View className="items-center justify-center flex-1 pt-100">
-                <LoadingCircle />
-              </View>
-            )}
             {!!selectedStation.departure.stationName &&
               !!selectedStation.arrival.stationName &&
               !data &&

--- a/appFrontend/src/screens/onboardingScreen/OnboardingWalkTimeScreen.tsx
+++ b/appFrontend/src/screens/onboardingScreen/OnboardingWalkTimeScreen.tsx
@@ -6,7 +6,6 @@ import { useRoute } from '@react-navigation/native';
 import type { StationDataTypes } from '@/store/modules';
 import { useSavedSubwayRoute } from '@/global/apis/hooks';
 import { SubwaySimplePath } from '@/global/components';
-import LoadingCircle from '@/global/components/animations/LoadingCircle';
 import { FontText } from '@/global/ui';
 import { useOnboardingNavigation } from '@/navigation/OnboardingNavigation';
 import { OnboardingStackParamList } from '@/navigation/types/navigation';
@@ -45,7 +44,7 @@ const OnboardingWalkTimeScreen = () => {
 
   const newPathName = '출근길' + Math.floor(Math.random() * 1000) + 1;
 
-  const { mutate, isLoading } = useSavedSubwayRoute({
+  const { mutate } = useSavedSubwayRoute({
     onSuccess: async (newPathId) => {
       trackMapBookmark5Finish({ ...pathData, name: newPathName });
       onboardingNavigation.push('OnboardingSetAlert', {
@@ -72,11 +71,6 @@ const OnboardingWalkTimeScreen = () => {
 
   return (
     <SafeAreaView className="relative flex-1 px-16 bg-gray-9f9">
-      {isLoading && (
-        <View className="absolute items-center justify-center w-full h-full">
-          <LoadingCircle />
-        </View>
-      )}
       <OnboardingHeader />
       <View className="pt-16 pb-14">
         <View className="relative">

--- a/appFrontend/src/screens/onboardingScreen/OnboardingWalkTimeScreen.tsx
+++ b/appFrontend/src/screens/onboardingScreen/OnboardingWalkTimeScreen.tsx
@@ -4,12 +4,10 @@ import React, { useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useRoute } from '@react-navigation/native';
 import type { StationDataTypes } from '@/store/modules';
-import { useSavedSubwayRoute } from '@/global/apis/hooks';
 import { SubwaySimplePath } from '@/global/components';
 import { FontText } from '@/global/ui';
 import { useOnboardingNavigation } from '@/navigation/OnboardingNavigation';
 import { OnboardingStackParamList } from '@/navigation/types/navigation';
-import { trackMapBookmark5Finish } from '@/analytics/map.events';
 import { useAppSelect } from '@/store';
 import { OnboardingHeader } from './components';
 
@@ -35,31 +33,12 @@ const OnboardingWalkTimeScreen = () => {
     }));
   };
 
-  const pathData = {
-    station_departure: newPath.firstStartStation,
-    station_arrival: newPath.lastEndStation,
-    line_departure: newPath.subPaths[1].name,
-    line_arrival: newPath.subPaths.at(-2)?.name!,
-  };
-
-  const newPathName = '출근길' + Math.floor(Math.random() * 1000) + 1;
-
-  const { mutate } = useSavedSubwayRoute({
-    onSuccess: async (newPathId) => {
-      trackMapBookmark5Finish({ ...pathData, name: newPathName });
-      onboardingNavigation.push('OnboardingSetAlert', {
-        newPath: { ...newPath, roadName: newPathName, id: newPathId },
-      });
-    },
-    onError: () => {},
-  });
-
+  // 경로 저장은 마지막 단계(OnboardingPathName)에서 1회만 수행한다.
+  // 여기서는 입력한 도보 시간만 다음 화면으로 넘긴다.
   const handleNext = () =>
-    mutate({
-      ...newPath,
-      roadName: newPathName,
-      walkingTimeFromStartStation: walkTime.before,
-      walkingTimeToEndStation: walkTime.after,
+    onboardingNavigation.push('OnboardingSetAlert', {
+      newPath,
+      walkTime,
     });
 
   const totalTime = newPath.totalTime + walkTime.before + walkTime.after;

--- a/appFrontend/src/screens/onboardingScreen/components/OnboardingSearchModal.tsx
+++ b/appFrontend/src/screens/onboardingScreen/components/OnboardingSearchModal.tsx
@@ -16,7 +16,6 @@ import { getSeletedStation } from '@/store/modules/stationSearchModule';
 import { DisplayLineName, LineCapsules, OriginLineName } from '@/global/apis/entity';
 import { searchStationsInLine } from '@/global/apis/func';
 import { useAddRecentSearch, useSearchStationName } from '@/global/apis/hooks';
-import LoadingCircle from '@/global/components/animations/LoadingCircle';
 import { COLOR } from '@/global/constants';
 import { FontText, Input } from '@/global/ui';
 import { displayToOrigin, lineCapsuleToOrigin } from '@/global/utils';
@@ -37,7 +36,7 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
 
   // N호선 캡슐로 N호선의 모든 역 불러오기
   const [activeButton, setActiveButton] = useState<LineCapsules>('전체');
-  const { data: searchStationsInLineData, isLoading: isLoadingLine } = useQuery(
+  const { data: searchStationsInLineData } = useQuery(
     ['searchStationsInLine', activeButton],
     () => searchStationsInLine({ line: lineCapsuleToOrigin(activeButton) ?? '전체' }),
     { enabled: !!activeButton },
@@ -51,7 +50,7 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
   const { searchResultData, isLoading: isLoadingSearch } = useSearchStationName(searchTextValue);
 
   // 클릭된 역을 최근검색 역에 저장(서버) -> 성공 시 전역변수에도 저장하고 모달 닫기
-  const { addRecentMutate, isLoadingAddRecent } = useAddRecentSearch({
+  const { addRecentMutate } = useAddRecentSearch({
     onSuccess: ({ stationLine, stationName }) => {
       const key = stationType === '출발역' ? 'departure' : 'arrival';
       dispatch(
@@ -108,11 +107,6 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
   return (
     <Modal visible onRequestClose={closeModal}>
       <View className="flex-1 bg-black/60">
-        {isLoadingAddRecent && (
-          <View className="absolute left-[44%] top-1/2 z-10">
-            <LoadingCircle />
-          </View>
-        )}
         <KeyboardAvoidingView
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
           className="justify-end flex-1"
@@ -152,11 +146,6 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
             {!searchTextValue ? (
               <View className="flex-1">
                 <LaneButtons activeButton={activeButton} setActiveButton={setActiveButton} />
-                {!searchStationsInLineData && isLoadingLine && (
-                  <View className="items-center justify-center flex-1">
-                    <LoadingCircle />
-                  </View>
-                )}
                 <ScrollView keyboardShouldPersistTaps="handled">
                   {searchStationsInLineData?.map(({ name, line }, idx) => (
                     <Pressable
@@ -192,11 +181,6 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
               </View>
             ) : (
               <View className="flex-1">
-                {searchResultData.length < 1 && isLoadingSearch && (
-                  <View className="items-center justify-center flex-1">
-                    <LoadingCircle />
-                  </View>
-                )}
                 {/* 입력어가 있고 && 검색 결과가 없으면 없음 표시 */}
                 {searchResultData.length < 1 && !isLoadingSearch && (
                   <View className="items-center justify-center flex-1 gap-17">

--- a/appFrontend/src/screens/onboardingScreen/components/OnboardingSearchModal.tsx
+++ b/appFrontend/src/screens/onboardingScreen/components/OnboardingSearchModal.tsx
@@ -16,6 +16,7 @@ import { getSeletedStation } from '@/store/modules/stationSearchModule';
 import { DisplayLineName, LineCapsules, OriginLineName } from '@/global/apis/entity';
 import { searchStationsInLine } from '@/global/apis/func';
 import { useAddRecentSearch, useSearchStationName } from '@/global/apis/hooks';
+import LoadingCircle from '@/global/components/animations/LoadingCircle';
 import { COLOR } from '@/global/constants';
 import { FontText, Input } from '@/global/ui';
 import { displayToOrigin, lineCapsuleToOrigin } from '@/global/utils';
@@ -36,7 +37,7 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
 
   // N호선 캡슐로 N호선의 모든 역 불러오기
   const [activeButton, setActiveButton] = useState<LineCapsules>('전체');
-  const { data: searchStationsInLineData } = useQuery(
+  const { data: searchStationsInLineData, isLoading: isLoadingLine } = useQuery(
     ['searchStationsInLine', activeButton],
     () => searchStationsInLine({ line: lineCapsuleToOrigin(activeButton) ?? '전체' }),
     { enabled: !!activeButton },
@@ -50,7 +51,7 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
   const { searchResultData, isLoading: isLoadingSearch } = useSearchStationName(searchTextValue);
 
   // 클릭된 역을 최근검색 역에 저장(서버) -> 성공 시 전역변수에도 저장하고 모달 닫기
-  const { addRecentMutate } = useAddRecentSearch({
+  const { addRecentMutate, isLoadingAddRecent } = useAddRecentSearch({
     onSuccess: ({ stationLine, stationName }) => {
       const key = stationType === '출발역' ? 'departure' : 'arrival';
       dispatch(
@@ -109,10 +110,10 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
       <View className="flex-1 bg-black/60">
         <KeyboardAvoidingView
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-          className="justify-end flex-1"
+          className="flex-1 justify-end"
         >
           <Animated.View
-            className="relative flex-1 bg-white top-60"
+            className="relative top-60 flex-1 bg-white"
             style={{
               borderTopStartRadius: 14,
               borderTopEndRadius: 14,
@@ -120,7 +121,7 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
               transform: [{ translateY: animRef }],
             }}
           >
-            <TouchableOpacity hitSlop={20} className="flex items-center mt-12" onPress={closeModal}>
+            <TouchableOpacity hitSlop={20} className="mt-12 flex items-center" onPress={closeModal}>
               <View className="h-4 w-34 rounded-2 bg-gray-ddd" />
             </TouchableOpacity>
 
@@ -130,7 +131,7 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
               fontWeight="600"
             />
 
-            <View className="flex-row items-center px-10 mx-16 space-x-12 my-14 rounded-8 bg-gray-9f9 py-9">
+            <View className="mx-16 my-14 flex-row items-center space-x-12 rounded-8 bg-gray-9f9 px-10 py-9">
               <IconSearch />
               <Input
                 className="leading-21"
@@ -146,6 +147,11 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
             {!searchTextValue ? (
               <View className="flex-1">
                 <LaneButtons activeButton={activeButton} setActiveButton={setActiveButton} />
+                {!searchStationsInLineData && isLoadingLine && (
+                  <View className="flex-1 items-center justify-center">
+                    <LoadingCircle />
+                  </View>
+                )}
                 <ScrollView keyboardShouldPersistTaps="handled">
                   {searchStationsInLineData?.map(({ name, line }, idx) => (
                     <Pressable
@@ -172,7 +178,7 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
                       ))}
                       <FontText
                         text={name.split('(')[0]}
-                        className="text-black text-14 leading-21"
+                        className="text-14 leading-21 text-black"
                         fontWeight="500"
                       />
                     </Pressable>
@@ -183,7 +189,7 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
               <View className="flex-1">
                 {/* 입력어가 있고 && 검색 결과가 없으면 없음 표시 */}
                 {searchResultData.length < 1 && !isLoadingSearch && (
-                  <View className="items-center justify-center flex-1 gap-17">
+                  <View className="flex-1 items-center justify-center gap-17">
                     <IconNoResult />
                     <FontText
                       text="검색 결과가 없습니다!"
@@ -212,7 +218,7 @@ const OnboardingSearchModal = ({ closeModal }: Props) => {
                         <LineNum displayName={stationLine ?? '1호선'} />
                         <FontText
                           text={stationName.split('(')[0]}
-                          className="text-black text-14 leading-21"
+                          className="text-14 leading-21 text-black"
                           fontWeight="500"
                         />
                       </Pressable>

--- a/appFrontend/src/screens/savePathScreen/SavedPathsScreen.tsx
+++ b/appFrontend/src/screens/savePathScreen/SavedPathsScreen.tsx
@@ -65,7 +65,7 @@ const SavedPathsScreen = () => {
     return <NetworkErrorScreen retryFn={getSavedRoutesRefetch} />;
   }
   return (
-    <SafeAreaView className="flex-1 bg-gray-9f9">
+    <SafeAreaView className="flex-1 bg-gray-9f9" edges={['top']}>
       <MyTabModal
         isVisible={popupVisible}
         onCancel={hideModal}
@@ -80,7 +80,7 @@ const SavedPathsScreen = () => {
         </TouchableOpacity>
         <FontText text="저장경로 편집" className="text-18 leading-23" fontWeight="500" />
       </View>
-      <ScrollView>
+      <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
         <View className="mx-16 rounded-15 bg-white">
           {myRoutes?.map((item) => (
             <View className="border-b-1 border-gray-beb px-16 pb-24 pt-20" key={item.id}>


### PR DESCRIPTION
## 개요
온보딩 경로 저장 플로우의 중복 저장 버그를 수정하고, 저장 경로(get_roads) 관련 크래시 방어 및 타입 정확도를 개선했습니다. 더불어 온보딩 화면의 불필요한 로딩 스피너를 정리했습니다.

## 주요 변경

### 🐛 온보딩 경로 중복 저장 제거
- 기존: `OnboardingWalkTime`에서 경로 저장 + `OnboardingPathName`에서 또 저장 → **경로가 2번 생성**됨 (알림 설정 API가 경로 id를 필요로 해 임시로 넣어둔 구조)
- 변경: 도보 시간/알림 설정 입력값을 네비게이션 파라미터로 끝까지 전달하고, **마지막 단계에서 경로 저장 1회 → 알림 설정 저장 1회**만 수행
- `OnboardingWalkTime`/`OnboardingAlertSettings` 타입 추가, `SetAlert`/`PathName` 파라미터에 반영

### 🐛 저장 경로 안정성 / 스키마 정확도
- `MyRoutesType`을 실제 `get_roads` 응답 형태로 재정의 (응답에 없는 `firstStartStation`/`stationTransitCount`/`myPath`/`myPathId` 제거, `transitStationList` null 허용, `stations.stationCode` 추가)
- `MyRoutes`: 스키마가 깨진 경로(subPaths 누락 등)는 렌더링에서 제외해 앱 크래시 방어 + Sentry 로깅
- `IssuesBanner`/`SubwaySimplePath`: `subPaths`/`stations` 누락 시 옵셔널 체이닝으로 크래시 방지

### 💄 온보딩 로딩 스피너 정리
- 과도하게 사용된 `LoadingCircle` 제거 (검색 모달 호선별 역 로딩 스피너는 복원)
- 저장경로 편집 화면 여백 조정

## 참고
- 10개 커밋으로 구성되어 있습니다.
- 알림(enable/disable) 관련 이슈는 작성자가 별도로 해결 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)