### PR TITLE
CI: Xcode Cloud ci_post_clone.sh 추가 (iOS 빌드 127 에러 해결)

### DIFF
--- a/appFrontend/ios/ci_scripts/ci_post_clone.sh
+++ b/appFrontend/ios/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,52 @@
+#!/bin/zsh
+
+# ci_post_clone.sh
+# Xcode Cloud가 레포 클론 직후 실행하는 스크립트.
+# React Native(gazinow) 앱 빌드 전에 Node / JS 의존성 / CocoaPods를 설치한다.
+# 이 파일은 .xcworkspace 와 같은 위치(ios/) 옆의 ci_scripts/ 에 있어야 한다.
+
+set -e
+
+echo "===== [ci_post_clone] start ====="
+
+# 모노레포: 레포 루트(frontend) 아래 appFrontend 에 RN 앱이 있다.
+APP_DIR="$CI_PRIMARY_REPOSITORY_PATH/appFrontend"
+echo "[ci_post_clone] APP_DIR=$APP_DIR"
+
+# --- 1) Node 설치 (Xcode Cloud 빌드 머신에는 Homebrew가 있다) ---
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+
+brew install node@20
+brew link --overwrite --force node@20
+export PATH="$(brew --prefix node@20)/bin:$PATH"
+
+echo "[ci_post_clone] node=$(command -v node) ($(node -v))"
+echo "[ci_post_clone] npm=$(command -v npm) ($(npm -v))"
+
+# --- 2) Yarn(classic) 설치 ---
+# 이 프로젝트는 yarn lockfile v1(classic)을 사용한다.
+npm install -g yarn
+echo "[ci_post_clone] yarn=$(command -v yarn) ($(yarn -v))"
+
+# --- 3) JS 의존성 설치 ---
+cd "$APP_DIR"
+yarn install --frozen-lockfile
+
+# --- 4) Xcode 빌드 단계가 node를 찾을 수 있도록 NODE_BINARY 고정 ---
+# "Bundle React Native code and images" 등 빌드 페이즈는 ios/.xcode.env(.local)을 source 한다.
+# ci_post_clone의 PATH는 xcodebuild로 전파되지 않으므로 여기서 절대경로를 박아준다.
+echo "export NODE_BINARY=$(command -v node)" > "$APP_DIR/ios/.xcode.env.local"
+echo "[ci_post_clone] wrote ios/.xcode.env.local -> NODE_BINARY=$(command -v node)"
+
+# --- 5) CocoaPods 설치 ---
+# Gemfile은 appFrontend/ 에 있고, Podfile은 appFrontend/ios/ 에 있다.
+export BUNDLE_GEMFILE="$APP_DIR/Gemfile"
+cd "$APP_DIR"
+gem install bundler --no-document
+bundle install
+
+cd "$APP_DIR/ios"
+bundle exec pod install --repo-update
+
+echo "===== [ci_post_clone] done ====="


### PR DESCRIPTION
## 배경
GitHub에 표시되던 빌드 실패는 **Xcode Cloud의 iOS 아카이브 빌드**(`gazinow | Default | Archive - iOS`)에서 발생한 `Exited with status code 127`(command not found)이었습니다. webFrontend와는 무관합니다.

원인은 Xcode Cloud 환경에 `ci_scripts/ci_post_clone.sh`가 없어 Node / JS 의존성 / CocoaPods 설치가 이뤄지지 않은 것입니다.

## 변경 사항
`appFrontend/ios/ci_scripts/ci_post_clone.sh` 추가:
- Node 20 + yarn(classic) 설치
- `appFrontend`에서 `yarn install --frozen-lockfile`
- `ios/.xcode.env.local`에 `NODE_BINARY` 절대경로 기록 (빌드 페이즈가 node 인식)
- `bundle install` → `bundle exec pod install`

## ⚠️ 후속 확인 필요
`.env.production`이 git에 커밋되어 있지 않아(`.gitignore`의 `.env.*`), 프로덕션 빌드에서 환경변수가 누락될 수 있습니다. Xcode Cloud Environment Variables 또는 ci 스크립트에서 처리 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)