### PR TITLE
CI: ci_post_clone gem 권한 오류 수정 (GEM_HOME)

### DIFF
--- a/appFrontend/ios/ci_scripts/ci_post_clone.sh
+++ b/appFrontend/ios/ci_scripts/ci_post_clone.sh
@@ -41,7 +41,11 @@ echo "[ci_post_clone] wrote ios/.xcode.env.local -> NODE_BINARY=$(command -v nod
 
 # --- 5) CocoaPods 설치 ---
 # Gemfile은 appFrontend/ 에 있고, Podfile은 appFrontend/ios/ 에 있다.
+# 시스템 Ruby(/Library/Ruby) 디렉터리는 쓰기 권한이 없으므로 gem을 사용자 경로에 설치한다.
+export GEM_HOME="$HOME/.gem"
+export PATH="$GEM_HOME/bin:$PATH"
 export BUNDLE_GEMFILE="$APP_DIR/Gemfile"
+
 cd "$APP_DIR"
 gem install bundler --no-document
 bundle install


### PR DESCRIPTION
PR #145에서 누락된 gem 권한 수정 커밋을 적용합니다.

시스템 Ruby(`/Library/Ruby/Gems/2.6.0`) 쓰기 권한이 없어 `gem install bundler`가 실패하던 문제를, gem을 사용자 경로(`GEM_HOME=$HOME/.gem`)에 설치하도록 변경해 해결합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)