### PR TITLE
CI: bundler 1.17.2 고정 (Xcode Cloud Ruby 2.6 호환)

### DIFF
--- a/appFrontend/ios/ci_scripts/ci_post_clone.sh
+++ b/appFrontend/ios/ci_scripts/ci_post_clone.sh
@@ -47,10 +47,12 @@ export PATH="$GEM_HOME/bin:$PATH"
 export BUNDLE_GEMFILE="$APP_DIR/Gemfile"
 
 cd "$APP_DIR"
-gem install bundler --no-document
-bundle install
+# Xcode Cloud의 시스템 Ruby는 2.6.10이라 최신 bundler(Ruby 3.2+ 요구)는 설치 불가.
+# Gemfile.lock의 "BUNDLED WITH"(1.17.2)와 동일하게 고정한다 (Ruby 2.6 호환).
+gem install bundler -v 1.17.2 --no-document
+bundle _1.17.2_ install
 
 cd "$APP_DIR/ios"
-bundle exec pod install --repo-update
+bundle _1.17.2_ exec pod install --repo-update
 
 echo "===== [ci_post_clone] done ====="


### PR DESCRIPTION
Xcode Cloud 시스템 Ruby가 2.6.10이라 최신 bundler(Ruby >= 3.2 요구) 설치가 실패했습니다.
Gemfile.lock의 `BUNDLED WITH` 버전(1.17.2)과 동일하게 고정해 해결합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)