### PR TITLE
Fix(iOS): fmt consteval 컴파일 에러 회피 (FMT_USE_CONSTEVAL=0)

### DIFF
--- a/appFrontend/ios/Podfile
+++ b/appFrontend/ios/Podfile
@@ -43,5 +43,15 @@ target 'gazinow' do
       config[:reactNativePath],
       :mac_catalyst_enabled => false
     )
+
+    # fmt 라이브러리(RCT-Folly가 사용)가 최신 Xcode/Clang의 consteval 평가와 충돌해
+    # "Call to consteval function ... is not a constant expression" 에러가 난다.
+    # FMT_USE_CONSTEVAL=0 으로 consteval 사용을 끄면 회피된다.
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FMT_USE_CONSTEVAL=0'
+      end
+    end
   end
 end


### PR DESCRIPTION
## 문제
Xcode Cloud 아카이브 빌드의 컴파일 단계에서 RCT-Folly가 사용하는 `fmt` 라이브러리가
최신 Xcode/Clang의 consteval 평가와 충돌해 실패:
`Call to consteval function ... is not a constant expression` (format-inl.h).

## 해결
Podfile `post_install`에서 모든 pod 타깃에 `FMT_USE_CONSTEVAL=0` 전처리 매크로를 추가해
fmt가 consteval을 사용하지 않도록 함.

로컬 `pod install`로 적용 확인 (256개 빌드 컨피그에 매크로 반영).

🤖 Generated with [Claude Code](https://claude.com/claude-code)