### PR TITLE
CI: .env.production / sentry.properties 빌드 시 생성

### DIFF
--- a/appFrontend/ios/ci_scripts/ci_post_clone.sh
+++ b/appFrontend/ios/ci_scripts/ci_post_clone.sh
@@ -33,6 +33,29 @@ echo "[ci_post_clone] yarn=$(command -v yarn) ($(yarn -v))"
 cd "$APP_DIR"
 yarn install --frozen-lockfile
 
+# --- 3-1) 민감정보 설정 파일 생성 (Xcode Cloud 환경변수로부터) ---
+# .env.production / ios/sentry.properties 는 gitignore라 레포에 없다.
+# App Store Connect의 Xcode Cloud Environment Variables 값으로 빌드 시점에 생성한다.
+echo "[ci_post_clone] generating .env.production"
+cat > "$APP_DIR/.env.production" <<ENVEOF
+MODE=production
+API_BASE_URL=${API_BASE_URL}
+SENTRY_DSN=${SENTRY_DSN}
+AMPLITUDE_API_KEY=${AMPLITUDE_API_KEY}
+ENVEOF
+
+echo "[ci_post_clone] generating ios/sentry.properties"
+cat > "$APP_DIR/ios/sentry.properties" <<SENTRYEOF
+auth.token=${SENTRY_AUTH_TOKEN}
+defaults.org=${SENTRY_ORG}
+defaults.project=${SENTRY_PROJECT}
+defaults.url=${SENTRY_URL:-https://sentry.io}
+SENTRYEOF
+
+# 필수 환경변수 누락 시 빌드를 일찍 실패시켜 원인을 명확히 한다.
+: "${API_BASE_URL:?API_BASE_URL 환경변수가 비어있음 (Xcode Cloud Env Vars 확인)}"
+: "${SENTRY_AUTH_TOKEN:?SENTRY_AUTH_TOKEN 환경변수가 비어있음 (Xcode Cloud Env Vars 확인)}"
+
 # --- 4) Xcode 빌드 단계가 node를 찾을 수 있도록 NODE_BINARY 고정 ---
 # "Bundle React Native code and images" 등 빌드 페이즈는 ios/.xcode.env(.local)을 source 한다.
 # ci_post_clone의 PATH는 xcodebuild로 전파되지 않으므로 여기서 절대경로를 박아준다.


### PR DESCRIPTION
민감정보(.env.production, ios/sentry.properties)는 gitignore라 레포에 없으므로,
Xcode Cloud Environment Variables 값으로 ci_post_clone.sh에서 빌드 시점에 생성한다.

필요한 Xcode Cloud 환경변수:
- API_BASE_URL, SENTRY_DSN, AMPLITUDE_API_KEY (.env.production)
- SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT (sentry.properties)
- ENVFILE=.env.production (react-native-config가 읽을 파일 지정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)